### PR TITLE
feat(CBP-48900): Add policy-subject output and update image versions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,10 @@ NOTE: The binary file must be in the TAR format.
 | String
 | The number of *Low* security findings discovered during the scan.
 
+| `policy-subject`
+| JSON
+| A JSON value containing details about the vulnerability scan summary and details.
+
 |===
 
 == Usage examples
@@ -130,6 +134,7 @@ jobs:
             echo "High count: ${{steps.grype-step.outputs.high-count}}"
             echo "Medium count: ${{steps.grype-step.outputs.medium-count}}"
             echo "Low count: ${{steps.grype-step.outputs.low-count}}"
+            echo "Policy subject: ${{steps.grype-step.outputs.policy-subject}}"
 
 
 ----
@@ -161,6 +166,7 @@ jobs:
       grype-job-output-high: ${{ steps.grype-step.outputs.high-count }}
       grype-job-output-medium: ${{ steps.grype-step.outputs.medium-count }}
       grype-job-output-low: ${{ steps.grype-step.outputs.low-count }}
+      grype-job-output-policy-subject: ${{ steps.grype-step.outputs.policy-subject }}
     steps:
       - name: check out source code
         uses: cloudbees-io/checkout@v1
@@ -189,6 +195,7 @@ jobs:
           echo "High count: ${{ needs.job1.outputs.grype-job-output-high }}"
           echo "Medium count: ${{ needs.job1.outputs.grype-job-output-medium }}"
           echo "Low count: ${{ needs.job1.outputs.grype-job-output-low }}"
+          echo "Policy subject: ${{ needs.job1.outputs.grype-job-output-policy-subject }}"
 
 ----
 

--- a/action.yml
+++ b/action.yml
@@ -22,12 +22,25 @@ outputs:
   low-count:
     description: A string containing the number of Low security findings discovered during the scan.
     value: ${{steps.process-outputs.outputs.low-count}}
+  policy-subject:
+    description: A json value containing the details about the vulnerability scan summary & details.
+    value: ${{steps.process-outputs.outputs.policy-subject}}
 
 runs:
   using: composite
   steps:
+    - name: Clear asset store for container scan
+      uses: docker://alpine:latest
+      shell: sh
+      run: |
+        find $CLOUDBEES_WORKSPACE/store -mindepth 2 -maxdepth 2 \
+          -type d ! -name "discovered-profile-findings" \
+          -exec rm -rf {} +
+        rm -rf $CLOUDBEES_WORKSPACE/store/binary-assets
+        rm -rf $CLOUDBEES_WORKSPACE/store/request
+
     - name: Generate reference files 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:805ec930ea41c76375697b921a6a75601afaed3a
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:711eb70f766356e79b0ebbe7a30c03e1e9e67bb4
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "BINARY" --tags "BINARY_CONTAINER" --binary-tar-path ${{ inputs.binary-tar-path }}
@@ -35,9 +48,10 @@ runs:
           INPUT_CLOUDBEES_API_TOKEN: ${{ cloudbees.api.token }}
           INPUT_CLOUDBEES_API_URL: ${{ cloudbees.api.url }}
           INPUT_RUN_ID: ${{ cloudbees.run_id }}
-          
+
     - name: Run grype compliance plugin
       uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-grype-scanner:b1629a24bc9f100b6524f71b7680fc80953d9916
+      continue-on-error: true
       env:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
@@ -45,7 +59,7 @@ runs:
       run: /app/plugin-grype-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:805ec930ea41c76375697b921a6a75601afaed3a
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:711eb70f766356e79b0ebbe7a30c03e1e9e67bb4
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils


### PR DESCRIPTION
This pull request introduces a new output, `policy-subject`, to the action, providing detailed vulnerability scan results as a JSON object. It also updates the documentation and workflow examples to include this new output, and makes minor improvements to asset store cleanup and Docker image versions.

**New output and documentation updates:**

* Added a `policy-subject` output to `action.yml`, which provides a JSON value containing the vulnerability scan summary and details. Updated the output documentation accordingly.
* Updated `README.adoc` to document the new `policy-subject` output and show how to access it in workflow examples, including both direct step outputs and job outputs. [[1]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124R57-R60) [[2]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124R137) [[3]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124R169) [[4]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124R198)

**Workflow and maintenance improvements:**

* Added a step to clear the asset store before running the container scan, improving workspace hygiene.
* Updated Docker image versions for the `assets-plugin-chain-utils` step to use a newer image hash. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R25-R43) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R54-R62)
* Set `continue-on-error: true` for the grype compliance plugin step to allow workflows to continue even if the scan fails.