### PR TITLE
feat(CBP-48900): Update Docker image tags in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         fi
 
     - name: Generate reference files 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:711eb70f766356e79b0ebbe7a30c03e1e9e67bb4
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9b7088fcf5c8b127bc33b3caf9ed24a0124fe4e8
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "BINARY" --tags "BINARY_CONTAINER" --binary-tar-path ${{ inputs.binary-tar-path }}
@@ -52,7 +52,7 @@ runs:
           INPUT_RUN_ID: ${{ cloudbees.run_id }}
 
     - name: Run grype compliance plugin
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-grype-scanner:b1629a24bc9f100b6524f71b7680fc80953d9916
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-grype-scanner:711eb70f766356e79b0ebbe7a30c03e1e9e67bb4
       continue-on-error: true
       env:
           RUN_ID: ${{ cloudbees.run_id }}
@@ -61,7 +61,7 @@ runs:
       run: /app/plugin-grype-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:711eb70f766356e79b0ebbe7a30c03e1e9e67bb4
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9b7088fcf5c8b127bc33b3caf9ed24a0124fe4e8
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils


### PR DESCRIPTION
This pull request updates the container image versions used in the `action.yml` workflow file. The main changes involve bumping the versions of the `assets-plugin-chain-utils` and `assets-grype-scanner` Docker images to newer hashes, which likely include bug fixes or improvements.

Dependency updates:

* Updated `assets-plugin-chain-utils` Docker image to version `9b7088fcf5c8b127bc33b3caf9ed24a0124fe4e8` in both the "Generate reference files" and "Complete execution plan" steps. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L45-R45) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L64-R64)
* Updated `assets-grype-scanner` Docker image to version `711eb70f766356e79b0ebbe7a30c03e1e9e67bb4` in the "Run grype compliance plugin" step.