### PR TITLE
feat(CBP-48900): Update assets-plugin-chain-utils Docker image version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         fi
 
     - name: Generate reference files 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9b7088fcf5c8b127bc33b3caf9ed24a0124fe4e8
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9c6f7dd273dfaff6d1d03ffaac6cb0261f375e73
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "BINARY" --tags "BINARY_CONTAINER" --binary-tar-path ${{ inputs.binary-tar-path }}
@@ -61,7 +61,7 @@ runs:
       run: /app/plugin-grype-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9b7088fcf5c8b127bc33b3caf9ed24a0124fe4e8
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9c6f7dd273dfaff6d1d03ffaac6cb0261f375e73
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils


### PR DESCRIPTION
This pull request updates the version of the `assets-plugin-chain-utils` Docker image used in the workflow. The new image version likely includes bug fixes or improvements, but the workflow logic itself remains unchanged.

- Dependency update:
  * Updated the `assets-plugin-chain-utils` Docker image in two workflow steps from version `9b7088fcf5c8b127bc33b3caf9ed24a0124fe4e8` to `9c6f7dd273dfaff6d1d03ffaac6cb0261f375e73` in `action.yml`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L45-R45) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L64-R64)