### PR TITLE
[CBP-51806] Update to latest assets-plugin-chain-utils tag to fix api error.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         fi
 
     - name: Generate reference files 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9c6f7dd273dfaff6d1d03ffaac6cb0261f375e73
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "BINARY" --tags "BINARY_CONTAINER" --binary-tar-path ${{ inputs.binary-tar-path }}
@@ -61,7 +61,7 @@ runs:
       run: /app/plugin-grype-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9c6f7dd273dfaff6d1d03ffaac6cb0261f375e73
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils


### PR DESCRIPTION
Updates `public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils` docker image tag to `d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d` to fix api error.