### PR TITLE
feat(CBP-51359): Update Assets Plugin Chain Utils Version Commit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         fi
 
     - name: Generate reference files 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "BINARY" --tags "BINARY_CONTAINER" --binary-tar-path ${{ inputs.binary-tar-path }}
@@ -61,7 +61,7 @@ runs:
       run: /app/plugin-grype-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils


### PR DESCRIPTION
This pull request updates the version of the `assets-plugin-chain-utils` Docker image used in the `action.yml` workflow. The update ensures that the workflow uses a newer and potentially more secure or feature-complete version of the utility.

Dependency updates:

* Updated the `assets-plugin-chain-utils` Docker image from version `d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d` to `8ffcff74b5e47eb284c2b137a00b839db558fde1` in two workflow steps: "Generate reference files" and "Complete execution plan". [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L45-R45) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L64-R64)